### PR TITLE
fix(mrg): exit without error when using mrg --reverse

### DIFF
--- a/cmd/mrg/main.go
+++ b/cmd/mrg/main.go
@@ -68,6 +68,7 @@ Options:
 			os.Stderr.WriteString("\n")
 			os.Exit(1)
 		}
+		os.Exit(0)
 	}
 
 	// Read and parse JSON from stdin.


### PR DESCRIPTION
When using `mrg --reverse`, the code proceeds beyond the `if opts["--reverse"].(bool)` block and results in always exiting with exit code 1. `mrg --reverse` should not continue beyond this block.